### PR TITLE
Fix failing unit tests due to type error in catch block

### DIFF
--- a/tests/base.spec.ts
+++ b/tests/base.spec.ts
@@ -27,17 +27,9 @@ describe("Mock UUID tests", () => {
 
   test("MockUUID.get throws expected errors", () => {
     expect(() => mockUuid.get(1, 1, 1)).toThrow(Error);
-    try {
-      mockUuid.get(1, 6, 1);
-    } catch (e) {
-      expect(e.message).toContain("Version");
-    }
+    expect(() => mockUuid.get(1, 6, 1)).toThrow(/Version/);
     expect(() => mockUuid.get(1, 1, 2, -1)).toThrow(Error);
-    try {
-      mockUuid.get(1, 1, 2, 5);
-    } catch (e) {
-      expect(e.message).toContain("Variant");
-    }
+    expect(() => mockUuid.get(1, 1, 2, 5)).toThrow(/Variant/);
   });
 
   test("MockUUID.getGenerator render valid uuids", () => {


### PR DESCRIPTION
Having a couple issues attempting to use this module. (Thanks for sharing!)

After cloning the module and running `yarn install && yarn test` **the tests fail** due to 2 [type errors in catch blocks](https://stackoverflow.com/q/68240884) within the test. 

_This has no influence on the module's end-user functionality but merely in the tests._

```
$ jest --env=node --colors --coverage test
 FAIL  tests/base.spec.ts
  ● Test suite failed to run

    tests/base.spec.ts:33:14 - error TS2571: Object is of type 'unknown'.

    33       expect(e.message).toContain("Version");
                    ~
    tests/base.spec.ts:39:14 - error TS2571: Object is of type 'unknown'.

    39       expect(e.message).toContain("Variant");
                    ~
Test Suites: 1 failed, 1 total
```

The issue can be resolved by negating the need to specify a type for `e` in the catch blocks by simplifying the syntax in the test—as done in this PR.